### PR TITLE
changed versioning to semver + version bump to 8.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Then you can refer to seatsio-android as a regular package:
 
 ```
 dependencies {
-  implementation 'com.github.seatsio:seatsio-android:8'
+  implementation 'com.github.seatsio:seatsio-android:8.1.0'
 }
 ```
 

--- a/releasing.md
+++ b/releasing.md
@@ -1,3 +1,3 @@
-- Update `versionCode` and `versionName` in `seatsio-android-component/build.gradle`
+- Update `majorVersion`, `minorVersion` and/or `patchVersion` in `seatsio-android-component/build.gradle`
 - Update version number in README.md
 - Create release on github

--- a/seatsio-android-component/build.gradle
+++ b/seatsio-android-component/build.gradle
@@ -3,14 +3,18 @@ apply plugin: 'com.github.dcendents.android-maven'
 
 group='com.github.seatsio'
 
+def majorVersion = 8
+def minorVersion = 1
+def patchVersion = 0
+
 android {
     buildToolsVersion "28.0.3"
     compileSdkVersion 28
     defaultConfig {
         minSdkVersion 24
         targetSdkVersion 28
-        versionCode 8
-        versionName "8.0"
+        versionCode majorVersion * 10000 + minorVersion * 100 + patchVersion
+        versionName "${majorVersion}.${minorVersion}.${patchVersion}"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
 
     }


### PR DESCRIPTION
we're calculating versionCode and versionName now, based on three variables in build.gradle. 