### PR TITLE
Added proguard consumer rules

### DIFF
--- a/seatsio-android-component/build.gradle
+++ b/seatsio-android-component/build.gradle
@@ -12,7 +12,7 @@ android {
         minSdkVersion 29
         targetSdkVersion 34
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
-
+        consumerProguardFiles 'proguard-consumer-rules.pro'
     }
     buildTypes {
         release {

--- a/seatsio-android-component/proguard-consumer-rules.pro
+++ b/seatsio-android-component/proguard-consumer-rules.pro
@@ -1,0 +1,12 @@
+-keep class io.seats.** { *; }
+
+##---------------Begin: proguard configuration for Gson  ----------
+-keepattributes Signature
+-dontwarn sun.misc.**
+-keep class * extends com.google.gson.TypeAdapter
+-keep class * implements com.google.gson.TypeAdapterFactory
+-keep class * implements com.google.gson.JsonSerializer
+-keep class * implements com.google.gson.JsonDeserializer
+-keep,allowobfuscation,allowshrinking class com.google.gson.reflect.TypeToken
+-keep,allowobfuscation,allowshrinking class * extends com.google.gson.reflect.TypeToken
+##---------------End: proguard configuration for Gson  ----------

--- a/seatsio-android-sample/build.gradle
+++ b/seatsio-android-sample/build.gradle
@@ -15,6 +15,12 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
+        debug {
+            debuggable true
+            minifyEnabled true
+            shrinkResources true
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+        }
     }
     compileOptions {
         targetCompatibility 1.8


### PR DESCRIPTION
Proguard is a tool that shrinks that minifies the code inside an Android package. It mostly works out of the box, but you need to pass in some configuration (as reported by https://github.com/seatsio/seatsio-android/issues/82)

So now we're shipping a `proguard-consumer-rules.pro` file, which indicates how Proguard should behave. Projects that use our library will use this automagically.