### PR TITLE
changeConfig works even without numberOfPlacesToSelect

### DIFF
--- a/seatsio-android-component/src/main/java/io/seats/seatingChart/ConfigChange.java
+++ b/seatsio-android-component/src/main/java/io/seats/seatingChart/ConfigChange.java
@@ -16,7 +16,7 @@ public class ConfigChange {
     public String objectLabel;
 
     @Expose
-    public int numberOfPlacesToSelect;
+    public Integer numberOfPlacesToSelect;
 
     @Expose
     public Object maxSelectedObjects;


### PR DESCRIPTION
Fix for https://github.com/seatsio/seatsio-android/issues/112

We were passing 0 as `numberOfPlacesToSelect`, if it wasn't explicitly specified when calling `changeConfig`. That led to a validation error.