### PR TITLE
Add config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,4 +238,7 @@ protected void onCreate(Bundle savedInstanceState) {
 }
 ```
 
+Some event manager modes have additional properties. To use these properties, instantiate one of the 
+sub-classes of `EventManagerConfig`.
+
 Documentation for the event manager is available at https://docs.seats.io/docs/event-manager

--- a/seatsio-android-component/src/main/java/io/seats/CommonConfig.java
+++ b/seatsio-android-component/src/main/java/io/seats/CommonConfig.java
@@ -54,11 +54,13 @@ public class CommonConfig<T extends CommonConfig<?, ?>, U extends SeatsioWebView
 
     public String objectColor;
     public Function<SeatsioObject, String> tooltipInfo;
+    public Function<SeatsioObject, String> popoverInfo;
     public BiConsumer<SeatsioObject, TicketType> onObjectSelected;
     public BiConsumer<SeatsioObject, TicketType> onObjectDeselected;
     public Consumer<SeatsioObject> onObjectClicked;
     public Consumer<U> onChartRendered;
     public Consumer<U> onChartRenderingFailed;
+    public Consumer<U> onChartRerenderingStarted;
 
     public T setEvent(String event) {
         HashSet<String> events = new HashSet<>();
@@ -84,6 +86,11 @@ public class CommonConfig<T extends CommonConfig<?, ?>, U extends SeatsioWebView
 
     public T setTooltipInfo(Function<SeatsioObject, String> tooltipInfo) {
         this.tooltipInfo = tooltipInfo;
+        return (T) this;
+    }
+
+    public T popoverInfo(Function<SeatsioObject, String> popoverInfo) {
+        this.popoverInfo = popoverInfo;
         return (T) this;
     }
 
@@ -127,6 +134,11 @@ public class CommonConfig<T extends CommonConfig<?, ?>, U extends SeatsioWebView
         return (T) this;
     }
 
+    public T setOnChartRerenderingStarted(Consumer<U> onChartRerenderingStarted) {
+        this.onChartRerenderingStarted = onChartRerenderingStarted;
+        return (T) this;
+    }
+
     public T setOnObjectSelected(BiConsumer<SeatsioObject, TicketType> onObjectSelected) {
         this.onObjectSelected = onObjectSelected;
         return (T) this;
@@ -147,6 +159,10 @@ public class CommonConfig<T extends CommonConfig<?, ?>, U extends SeatsioWebView
 
         if (tooltipInfo != null) {
             callbacks.add("tooltipInfo: object => Native.tooltipInfo(JSON.stringify(object))");
+        }
+
+        if (popoverInfo != null) {
+            callbacks.add("popoverInfo: object => Native.popoverInfo(JSON.stringify(object))");
         }
 
         if (objectColor != null) {
@@ -171,6 +187,10 @@ public class CommonConfig<T extends CommonConfig<?, ?>, U extends SeatsioWebView
 
         if (onChartRenderingFailed != null) {
             callbacks.add("onChartRenderingFailed: object => Native.onChartRenderingFailed()");
+        }
+
+        if (onChartRerenderingStarted != null) {
+            callbacks.add("onChartRerenderingStarted: object => Native.onChartRerenderingStarted()");
         }
 
         return callbacks;

--- a/seatsio-android-component/src/main/java/io/seats/SeatsioJavascriptInterface.java
+++ b/seatsio-android-component/src/main/java/io/seats/SeatsioJavascriptInterface.java
@@ -50,6 +50,10 @@ public class SeatsioJavascriptInterface<U extends SeatsioWebView<?>, T extends C
         return config.tooltipInfo.apply(toSeatsObject(object));
     }
 
+    public String popoverInfo(String object) {
+        return config.popoverInfo.apply(toSeatsObject(object));
+    }
+
     @JavascriptInterface
     public void onChartRendered() {
         seatsioWebView.post(() -> config.onChartRendered.accept(seatsioWebView));
@@ -58,6 +62,11 @@ public class SeatsioJavascriptInterface<U extends SeatsioWebView<?>, T extends C
     @JavascriptInterface
     public void onChartRenderingFailed() {
         config.onChartRenderingFailed.accept(seatsioWebView);
+    }
+
+    @JavascriptInterface
+    public void onChartRerenderingStarted() {
+        config.onChartRerenderingStarted.accept(seatsioWebView);
     }
 
     @JavascriptInterface

--- a/seatsio-android-component/src/main/java/io/seats/SeatsioWebView.java
+++ b/seatsio-android-component/src/main/java/io/seats/SeatsioWebView.java
@@ -12,9 +12,16 @@ import android.webkit.WebView;
 
 import androidx.annotation.Nullable;
 
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+
+import java.lang.reflect.Type;
+import java.util.List;
 import java.util.function.Consumer;
 
+import io.seats.seatingChart.Category;
 import io.seats.seatingChart.SeatsioObject;
+import io.seats.seatingChart.SelectedObject;
 
 abstract public class SeatsioWebView<T extends WebView> extends WebView {
 
@@ -114,6 +121,81 @@ abstract public class SeatsioWebView<T extends WebView> extends WebView {
                     SeatsioObject seatsioObject = GSON.fromJson(object, SeatsioObject.class);
                     successCallback.accept(seatsioObject);
                 },
+                errorCallback
+        );
+    }
+
+    public void rerender() {
+        caller.call("chart.rerender()");
+    }
+
+    public void trySelectObjects(SelectedObject... selectedObjects) {
+        caller.call("chart.trySelectObjects(" + new Gson().toJson(selectedObjects) + ")");
+    }
+
+    public void doSelectObjects(SelectedObject... selectedObjects) {
+        caller.call("chart.doSelectObjects(" + new Gson().toJson(selectedObjects) + ")");
+    }
+
+    public void zoomToObjects(String ... labels) {
+        caller.call("chart.zoomToObjects(" + new Gson().toJson(labels) + ")");
+    }
+
+    public void resetView() {
+        caller.call("chart.resetView()");
+    }
+
+    public void selectCategories(String... categoryIds) {
+        caller.call("chart.selectCategories(" + new Gson().toJson(categoryIds) + ")");
+    }
+
+    public void deselectCategories(String... categoryIds) {
+        caller.call("chart.deselectCategories(" + new Gson().toJson(categoryIds) + ")");
+    }
+
+    public void zoomToSection(String label) {
+        caller.call("chart.zoomToSection(" + new Gson().toJson(label)+ ")");
+    }
+
+    public void zoomToSelectedObjects() {
+        caller.call("chart.zoomToSelectedObjects()");
+    }
+
+    public void pulseObject(String objectLabel) {
+        caller.call("chart.findObject(" + new Gson().toJson(objectLabel) + ").then(object => object.pulse())");
+    }
+
+    public void unpulseObject(String objectLabel) {
+        caller.call("chart.findObject(" + new Gson().toJson(objectLabel) + ").then(object => object.unpulse())");
+    }
+
+    public void listSelectedObjects(Consumer<List<SeatsioObject>> callback) {
+        caller.callAsync(
+                "chart.listSelectedObjects()",
+                objects -> {
+                    Type listType = new TypeToken<List<SeatsioObject>>() {
+                    }.getType();
+                    List<SeatsioObject> seatsioObjects = GSON.fromJson(objects, listType);
+                    callback.accept(seatsioObjects);
+                }
+        );
+    }
+
+    public void listCategories(Consumer<List<Category>> callback) {
+        caller.callAsync(
+                "chart.listCategories()",
+                categories -> {
+                    Type listType = new TypeToken<List<Category>>() {
+                    }.getType();
+                    callback.accept(GSON.fromJson(categories, listType));
+                }
+        );
+    }
+
+    public void clearSelection(Runnable successCallback, Runnable errorCallback) {
+        caller.callAsync(
+                "chart.clearSelection()",
+                object -> successCallback.run(),
                 errorCallback
         );
     }

--- a/seatsio-android-component/src/main/java/io/seats/eventManager/CategoryWithTicketTypes.java
+++ b/seatsio-android-component/src/main/java/io/seats/eventManager/CategoryWithTicketTypes.java
@@ -1,0 +1,21 @@
+package io.seats.eventManager;
+
+import static java.util.Arrays.asList;
+
+import com.google.gson.annotations.Expose;
+
+import java.util.List;
+
+public class CategoryWithTicketTypes {
+
+    @Expose
+    public Integer category;
+
+    @Expose
+    public List<TicketType> ticketTypes;
+
+    public CategoryWithTicketTypes(Integer category, TicketType... ticketTypes) {
+        this.category = category;
+        this.ticketTypes = asList(ticketTypes);
+    }
+}

--- a/seatsio-android-component/src/main/java/io/seats/eventManager/EventManagerConfig.java
+++ b/seatsio-android-component/src/main/java/io/seats/eventManager/EventManagerConfig.java
@@ -2,7 +2,13 @@ package io.seats.eventManager;
 
 import com.google.gson.annotations.Expose;
 
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
 import io.seats.CommonConfig;
+import io.seats.seatingChart.SeatsioObject;
+import io.seats.utils.Function3;
 
 public class EventManagerConfig extends CommonConfig<EventManagerConfig, EventManagerView> {
 
@@ -12,6 +18,10 @@ public class EventManagerConfig extends CommonConfig<EventManagerConfig, EventMa
     @Expose
     public EventManagerMode mode;
 
+    public Function<SeatsioObject, String> tooltipContents;
+
+    public Function3<SeatsioObject, String, Map<String, ?>, String> objectIcon;
+
     public EventManagerConfig setSecretKey(String secretKey) {
         this.secretKey = secretKey;
         return this;
@@ -20,5 +30,30 @@ public class EventManagerConfig extends CommonConfig<EventManagerConfig, EventMa
     public EventManagerConfig setMode(EventManagerMode mode) {
         this.mode = mode;
         return this;
+    }
+
+    public EventManagerConfig setTooltipContents(Function<SeatsioObject, String> tooltipContents) {
+        this.tooltipContents = tooltipContents;
+        return this;
+    }
+
+    public EventManagerConfig setObjectIcon(Function3<SeatsioObject, String, Map<String, ?>, String> objectIcon) {
+        this.objectIcon = objectIcon;
+        return this;
+    }
+
+    @Override
+    protected List<String> callbacks() {
+        List<String> callbacks = super.callbacks();
+
+        if (tooltipContents != null) {
+            callbacks.add("tooltipContents: (object) => Native.tooltipContents(JSON.stringify(object))");
+        }
+
+        if (objectIcon != null) {
+            callbacks.add("objectIcon: (object, defaultIcon, extraConfig) => Native.objectIcon(JSON.stringify(object), defaultIcon, extraConfig)");
+        }
+
+        return callbacks;
     }
 }

--- a/seatsio-android-component/src/main/java/io/seats/eventManager/EventManagerJavascriptInterface.java
+++ b/seatsio-android-component/src/main/java/io/seats/eventManager/EventManagerJavascriptInterface.java
@@ -1,5 +1,9 @@
 package io.seats.eventManager;
 
+import android.webkit.JavascriptInterface;
+
+import java.util.Map;
+
 import io.seats.SeatsioJavascriptInterface;
 
 public class EventManagerJavascriptInterface extends SeatsioJavascriptInterface<EventManagerView, EventManagerConfig> {
@@ -8,4 +12,18 @@ public class EventManagerJavascriptInterface extends SeatsioJavascriptInterface<
         super(config);
     }
 
+    @JavascriptInterface
+    public String tooltipContents(String object) {
+        return config.tooltipContents.apply(toSeatsObject(object));
+    }
+
+    @JavascriptInterface
+    public boolean isObjectSelectable(String object) {
+        return ((SelectModeConfig)config).isObjectSelectable.apply(toSeatsObject(object));
+    }
+
+    @JavascriptInterface
+    public String objectIcon(String object, String defaultIcon, String extraData) {
+        return config.objectIcon.apply(toSeatsObject(object), defaultIcon, GSON.fromJson(extraData, Map.class));
+    }
 }

--- a/seatsio-android-component/src/main/java/io/seats/eventManager/ManageCategoriesModeConfig.java
+++ b/seatsio-android-component/src/main/java/io/seats/eventManager/ManageCategoriesModeConfig.java
@@ -1,0 +1,14 @@
+package io.seats.eventManager;
+
+import com.google.gson.annotations.Expose;
+
+public class ManageCategoriesModeConfig extends EventManagerConfig {
+
+    @Expose
+    public Boolean unavailableObjectsSelectable;
+
+    public ManageCategoriesModeConfig setUnavailableObjectsSelectable(Boolean unavailableObjectsSelectable) {
+        this.unavailableObjectsSelectable = unavailableObjectsSelectable;
+        return this;
+    }
+}

--- a/seatsio-android-component/src/main/java/io/seats/eventManager/ManageChannelsModeConfig.java
+++ b/seatsio-android-component/src/main/java/io/seats/eventManager/ManageChannelsModeConfig.java
@@ -1,0 +1,22 @@
+package io.seats.eventManager;
+
+import com.google.gson.annotations.Expose;
+
+public class ManageChannelsModeConfig extends EventManagerConfig {
+
+    @Expose
+    public Boolean manageChannelsList;
+
+    @Expose
+    public Boolean unavailableObjectsSelectable;
+
+    public ManageChannelsModeConfig setManageChannelsList(Boolean manageChannelsList) {
+        this.manageChannelsList = manageChannelsList;
+        return this;
+    }
+
+    public ManageChannelsModeConfig setUnavailableObjectsSelectable(Boolean unavailableObjectsSelectable) {
+        this.unavailableObjectsSelectable = unavailableObjectsSelectable;
+        return this;
+    }
+}

--- a/seatsio-android-component/src/main/java/io/seats/eventManager/ManageObjectStatusesModeConfig.java
+++ b/seatsio-android-component/src/main/java/io/seats/eventManager/ManageObjectStatusesModeConfig.java
@@ -1,0 +1,14 @@
+package io.seats.eventManager;
+
+import com.google.gson.annotations.Expose;
+
+public class ManageObjectStatusesModeConfig extends EventManagerConfig {
+
+    @Expose
+    public String session;
+
+    public ManageObjectStatusesModeConfig setSession(String session) {
+        this.session = session;
+        return this;
+    }
+}

--- a/seatsio-android-component/src/main/java/io/seats/eventManager/ObjectPopover.java
+++ b/seatsio-android-component/src/main/java/io/seats/eventManager/ObjectPopover.java
@@ -1,0 +1,46 @@
+package io.seats.eventManager;
+
+import com.google.gson.annotations.Expose;
+
+public class ObjectPopover {
+
+    @Expose
+    public Boolean showOrderId;
+
+    @Expose
+    public Boolean showTechnicalLabel;
+
+    @Expose
+    public Boolean showLabel;
+
+    @Expose
+    public Boolean showCategory;
+
+    @Expose
+    public Boolean showChannel;
+
+    public ObjectPopover setShowOrderId(Boolean showOrderId) {
+        this.showOrderId = showOrderId;
+        return this;
+    }
+
+    public ObjectPopover setShowTechnicalLabel(Boolean showTechnicalLabel) {
+        this.showTechnicalLabel = showTechnicalLabel;
+        return this;
+    }
+
+    public ObjectPopover setShowLabel(Boolean showLabel) {
+        this.showLabel = showLabel;
+        return this;
+    }
+
+    public ObjectPopover setShowCategory(Boolean showCategory) {
+        this.showCategory = showCategory;
+        return this;
+    }
+
+    public ObjectPopover setShowChannel(Boolean showChannel) {
+        this.showChannel = showChannel;
+        return this;
+    }
+}

--- a/seatsio-android-component/src/main/java/io/seats/eventManager/SelectModeConfig.java
+++ b/seatsio-android-component/src/main/java/io/seats/eventManager/SelectModeConfig.java
@@ -1,0 +1,113 @@
+package io.seats.eventManager;
+
+import static java.util.Arrays.asList;
+
+import com.google.gson.annotations.Expose;
+
+import java.util.List;
+import java.util.function.Function;
+
+import io.seats.seatingChart.CategoryWithQuantity;
+import io.seats.seatingChart.CategoryWithTicketTypesAndQuantity;
+import io.seats.seatingChart.SeatsioObject;
+import io.seats.seatingChart.SelectedObject;
+import io.seats.seatingChart.TicketTypeWithQuantity;
+
+public class SelectModeConfig extends EventManagerConfig {
+
+    @Expose
+    public Object maxSelectedObjects;
+
+    @Expose
+    public Integer numberOfPlacesToSelect;
+
+    @Expose
+    public List<SelectedObject> selectedObjects;
+
+    @Expose
+    public String selectionBy;
+
+    public List<CategoryWithTicketTypes> ticketTypes;
+
+    @Expose
+    public ObjectPopover objectPopover;
+
+    @Expose
+    public Boolean unavailableObjectsSelectable;
+
+    @Expose
+    public List<String> selectableObjects;
+
+    public Function<SeatsioObject, Boolean> isObjectSelectable;
+
+    public SelectModeConfig setMaxSelectedObjects(int maxSelectedObjects) {
+        this.maxSelectedObjects = maxSelectedObjects;
+        return this;
+    }
+
+    public SelectModeConfig setMaxSelectedObjects(CategoryWithQuantity... maxSelectedObjects) {
+        this.maxSelectedObjects = asList(maxSelectedObjects);
+        return this;
+    }
+
+    public SelectModeConfig setMaxSelectedObjects(TicketTypeWithQuantity... maxSelectedObjects) {
+        this.maxSelectedObjects = asList(maxSelectedObjects);
+        return this;
+    }
+
+    public SelectModeConfig setMaxSelectedObjects(CategoryWithTicketTypesAndQuantity... maxSelectedObjects) {
+        this.maxSelectedObjects = asList(maxSelectedObjects);
+        return this;
+    }
+
+    public SelectModeConfig setNumberOfPlacesToSelect(Integer numberOfPlacesToSelect) {
+        this.numberOfPlacesToSelect = numberOfPlacesToSelect;
+        return this;
+    }
+
+    public SelectModeConfig setSelectedObjects(List<SelectedObject> selectedObjects) {
+        this.selectedObjects = selectedObjects;
+        return this;
+    }
+
+    public SelectModeConfig setSelectionBy(String selectionBy) {
+        this.selectionBy = selectionBy;
+        return this;
+    }
+
+    public SelectModeConfig setTicketTypes(CategoryWithTicketTypes... ticketTypes) {
+        this.ticketTypes = asList(ticketTypes);
+        return this;
+    }
+
+    public SelectModeConfig setObjectPopover(ObjectPopover objectPopover) {
+        this.objectPopover = objectPopover;
+        return this;
+    }
+
+    public SelectModeConfig setUnavailableObjectsSelectable(Boolean unavailableObjectsSelectable) {
+        this.unavailableObjectsSelectable = unavailableObjectsSelectable;
+        return this;
+    }
+
+    public SelectModeConfig setSelectableObjects(List<String> selectableObjects) {
+        this.selectableObjects = selectableObjects;
+        return this;
+    }
+
+    public SelectModeConfig setIsObjectSelectable(Function<SeatsioObject, Boolean> isObjectSelectable) {
+        this.isObjectSelectable = isObjectSelectable;
+        return this;
+    }
+
+    @Override
+    protected List<String> callbacks() {
+        List<String> callbacks = super.callbacks();
+
+        if (isObjectSelectable != null) {
+            callbacks.add("isObjectSelectable: (object) => Native.isObjectSelectable(JSON.stringify(object))");
+        }
+
+        return callbacks;
+    }
+}

--- a/seatsio-android-component/src/main/java/io/seats/eventManager/StaticModeConfig.java
+++ b/seatsio-android-component/src/main/java/io/seats/eventManager/StaticModeConfig.java
@@ -1,0 +1,19 @@
+package io.seats.eventManager;
+
+import com.google.gson.annotations.Expose;
+
+import java.util.Map;
+import java.util.function.Function;
+
+import io.seats.seatingChart.SeatsioObject;
+import io.seats.utils.Function3;
+
+public class StaticModeConfig extends EventManagerConfig {
+
+    @Expose
+    public ObjectPopover objectPopover;
+
+    public Function<SeatsioObject, String> tooltipContents;
+
+    public Function3<SeatsioObject, String, Map<String, ?>, String> objectIcon;
+}

--- a/seatsio-android-component/src/main/java/io/seats/eventManager/TicketType.java
+++ b/seatsio-android-component/src/main/java/io/seats/eventManager/TicketType.java
@@ -1,0 +1,30 @@
+package io.seats.eventManager;
+
+import com.google.gson.annotations.Expose;
+
+public class TicketType {
+
+    @Expose
+    public String ticketType;
+
+    @Expose
+    public String label;
+
+    @Expose
+    public String description;
+
+    public TicketType setTicketType(String ticketType) {
+        this.ticketType = ticketType;
+        return this;
+    }
+
+    public TicketType setLabel(String label) {
+        this.label = label;
+        return this;
+    }
+
+    public TicketType setDescription(String description) {
+        this.description = description;
+        return this;
+    }
+}

--- a/seatsio-android-component/src/main/java/io/seats/seatingChart/CategoryWithTicketTypesAndQuantity.java
+++ b/seatsio-android-component/src/main/java/io/seats/seatingChart/CategoryWithTicketTypesAndQuantity.java
@@ -1,0 +1,21 @@
+package io.seats.seatingChart;
+
+import static java.util.Arrays.asList;
+
+import com.google.gson.annotations.Expose;
+
+import java.util.List;
+
+public class CategoryWithTicketTypesAndQuantity {
+
+    @Expose
+    public String category;
+
+    @Expose
+    public List<TicketTypeWithQuantity> ticketTypes;
+
+    public CategoryWithTicketTypesAndQuantity(String category, TicketTypeWithQuantity... ticketTypes) {
+        this.category = category;
+        this.ticketTypes = asList(ticketTypes);
+    }
+}

--- a/seatsio-android-component/src/main/java/io/seats/seatingChart/ObjectPopover.java
+++ b/seatsio-android-component/src/main/java/io/seats/seatingChart/ObjectPopover.java
@@ -1,0 +1,70 @@
+package io.seats.seatingChart;
+
+import com.google.gson.annotations.Expose;
+
+public class ObjectPopover {
+
+    @Expose
+    public Boolean showAvailability;
+
+    @Expose
+    public Boolean showCategory;
+
+    @Expose
+    public Boolean showLabel;
+
+    @Expose
+    public Boolean showPricing;
+
+    @Expose
+    public Boolean showUnavailableNotice;
+
+    @Expose
+    public Boolean stylizedLabel;
+
+    @Expose
+    public String confirmSelection;
+
+    @Expose
+    public Boolean confirmTicketTypeSelection;
+
+    public ObjectPopover setShowAvailability(Boolean showAvailability) {
+        this.showAvailability = showAvailability;
+        return this;
+    }
+
+    public ObjectPopover setShowCategory(Boolean showCategory) {
+        this.showCategory = showCategory;
+        return this;
+    }
+
+    public ObjectPopover setShowLabel(Boolean showLabel) {
+        this.showLabel = showLabel;
+        return this;
+    }
+
+    public ObjectPopover setShowPricing(Boolean showPricing) {
+        this.showPricing = showPricing;
+        return this;
+    }
+
+    public ObjectPopover setShowUnavailableNotice(Boolean showUnavailableNotice) {
+        this.showUnavailableNotice = showUnavailableNotice;
+        return this;
+    }
+
+    public ObjectPopover setStylizedLabel(Boolean stylizedLabel) {
+        this.stylizedLabel = stylizedLabel;
+        return this;
+    }
+
+    public ObjectPopover setConfirmSelection(String confirmSelection) {
+        this.confirmSelection = confirmSelection;
+        return this;
+    }
+
+    public ObjectPopover setConfirmTicketTypeSelection(Boolean confirmTicketTypeSelection) {
+        this.confirmTicketTypeSelection = confirmTicketTypeSelection;
+        return this;
+    }
+}

--- a/seatsio-android-component/src/main/java/io/seats/seatingChart/SeatingChartConfig.java
+++ b/seatsio-android-component/src/main/java/io/seats/seatingChart/SeatingChartConfig.java
@@ -59,6 +59,9 @@ public class SeatingChartConfig extends CommonConfig<SeatingChartConfig, Seating
     public List<String> unavailableCategories;
 
     @Expose
+    public List<String> availableCategories;
+
+    @Expose
     public BestAvailable selectBestAvailable;
 
     @Expose
@@ -145,6 +148,12 @@ public class SeatingChartConfig extends CommonConfig<SeatingChartConfig, Seating
     public String activeFloor;
 
     @Expose
+    public Boolean lockActiveFloor;
+
+    @Expose
+    public Boolean showFloorElevator;
+
+    @Expose
     public Boolean showSectionPricingOverlay;
 
     @Expose
@@ -152,6 +161,13 @@ public class SeatingChartConfig extends CommonConfig<SeatingChartConfig, Seating
 
     @Expose
     public Boolean unifiedObjectPropertiesInCallbacks;
+
+    @Expose
+    public Boolean hideSectionsNotForSale;
+
+    @Expose
+    public ObjectPopover objectPopover;
+
 
     public BiConsumer<List<SeatsioObject>, Boolean> onBestAvailableSelected;
     public BiConsumer<List<SeatsioObject>, List<TicketType>> onHoldSucceeded;
@@ -326,8 +342,23 @@ public class SeatingChartConfig extends CommonConfig<SeatingChartConfig, Seating
         return this;
     }
 
+    public SeatingChartConfig setMaxSelectedObjects(TicketTypeWithQuantity... maxSelectedObjects) {
+        this.maxSelectedObjects = asList(maxSelectedObjects);
+        return this;
+    }
+
+    public SeatingChartConfig setMaxSelectedObjects(CategoryWithTicketTypesAndQuantity... maxSelectedObjects) {
+        this.maxSelectedObjects = asList(maxSelectedObjects);
+        return this;
+    }
+
     public SeatingChartConfig setUnavailableCategories(String... unavailableCategories) {
         this.unavailableCategories = asList(unavailableCategories);
+        return this;
+    }
+
+    public SeatingChartConfig setAvailableCategories(String... availableCategories) {
+        this.availableCategories = asList(availableCategories);
         return this;
     }
 
@@ -472,6 +503,16 @@ public class SeatingChartConfig extends CommonConfig<SeatingChartConfig, Seating
         return this;
     }
 
+    public SeatingChartConfig setLockActiveFloor(Boolean lockActiveFloor) {
+        this.lockActiveFloor = lockActiveFloor;
+        return this;
+    }
+
+    public SeatingChartConfig setShowFloorElevator(Boolean showFloorElevator) {
+        this.showFloorElevator = showFloorElevator;
+        return this;
+    }
+
     public SeatingChartConfig setShowSectionPricingOverlay(Boolean showSectionPricingOverlay) {
         this.showSectionPricingOverlay = showSectionPricingOverlay;
         return this;
@@ -484,6 +525,16 @@ public class SeatingChartConfig extends CommonConfig<SeatingChartConfig, Seating
 
     public SeatingChartConfig setUnifiedObjectPropertiesInCallbacks(Boolean unifiedObjectPropertiesInCallbacks) {
         this.unifiedObjectPropertiesInCallbacks = unifiedObjectPropertiesInCallbacks;
+        return this;
+    }
+
+    public SeatingChartConfig setHideSectionsNotForSale(Boolean hideSectionsNotForSale) {
+        this.hideSectionsNotForSale = hideSectionsNotForSale;
+        return this;
+    }
+
+    public SeatingChartConfig setObjectPopover(ObjectPopover objectPopover) {
+        this.objectPopover = objectPopover;
         return this;
     }
 

--- a/seatsio-android-component/src/main/java/io/seats/seatingChart/SeatingChartView.java
+++ b/seatsio-android-component/src/main/java/io/seats/seatingChart/SeatingChartView.java
@@ -8,10 +8,7 @@ import android.util.AttributeSet;
 import androidx.annotation.Nullable;
 
 import com.google.gson.Gson;
-import com.google.gson.reflect.TypeToken;
 
-import java.lang.reflect.Type;
-import java.util.List;
 import java.util.function.Consumer;
 
 import io.seats.Region;
@@ -50,15 +47,6 @@ public class SeatingChartView extends SeatsioWebView<SeatingChartView> {
         caller.call("chart.holdToken", callback);
     }
 
-    public void zoomToSelectedObjects() {
-        caller.call("chart.zoomToSelectedObjects()");
-    }
-
-
-    public void zoomToSection(String label) {
-        caller.call("chart.zoomToSection(" + new Gson().toJson(label)+ ")");
-    }
-
     public void selectBestAvailable(BestAvailable bestAvailable) {
         caller.call("chart.selectBestAvailable(" + new Gson().toJson(bestAvailable) + ")");
     }
@@ -87,30 +75,10 @@ public class SeatingChartView extends SeatsioWebView<SeatingChartView> {
         caller.call("chart.findObject(" + new Gson().toJson(objectLabel) + ").then(object => object.deselect(" + new Gson().toJson(ticketType) + "))");
     }
 
-    public void pulseObject(String objectLabel) {
-        caller.call("chart.findObject(" + new Gson().toJson(objectLabel) + ").then(object => object.pulse())");
-    }
-
-    public void unpulseObject(String objectLabel) {
-        caller.call("chart.findObject(" + new Gson().toJson(objectLabel) + ").then(object => object.unpulse())");
-    }
-
     public void isObjectInChannel(String objectLabel, String channel, Consumer<Boolean> callback) {
         caller.callAsync(
                 "chart.findObject(" + new Gson().toJson(objectLabel) + ").then(object => object.isInChannel(" + new Gson().toJson(channel) + "))",
                 r -> callback.accept(GSON.fromJson(r, Boolean.class))
-        );
-    }
-
-    public void listSelectedObjects(Consumer<List<SeatsioObject>> callback) {
-        caller.callAsync(
-                "chart.listSelectedObjects()",
-                objects -> {
-                    Type listType = new TypeToken<List<SeatsioObject>>() {
-                    }.getType();
-                    List<SeatsioObject> seatsioObjects = GSON.fromJson(objects, listType);
-                    callback.accept(seatsioObjects);
-                }
         );
     }
 
@@ -121,27 +89,19 @@ public class SeatingChartView extends SeatsioWebView<SeatingChartView> {
         );
     }
 
-    public void listCategories(Consumer<List<Category>> callback) {
-        caller.callAsync(
-                "chart.listCategories()",
-                categories -> {
-                    Type listType = new TypeToken<List<Category>>() {
-                    }.getType();
-                    callback.accept(GSON.fromJson(categories, listType));
-                }
-        );
-    }
-
-    public void clearSelection(Runnable successCallback, Runnable errorCallback) {
-        caller.callAsync(
-                "chart.clearSelection()",
-                object -> successCallback.run(),
-                errorCallback
-        );
-    }
-
     public void changeConfig(ConfigChange configChange) {
         caller.call("chart.changeConfig(" + new Gson().toJson(configChange) + ")");
     }
 
+    public void goToFloor(String floorName) {
+        caller.call("chart.goToFloor('" + floorName + "')");
+    }
+
+    public void goToAllFloorsView() {
+        caller.call("chart.goToAllFloorsView()");
+    }
+
+    public void zoomToFilteredCategories() {
+        caller.call("chart.zoomToFilteredCategories()");
+    }
 }

--- a/seatsio-android-component/src/main/java/io/seats/seatingChart/TicketTypeWithQuantity.java
+++ b/seatsio-android-component/src/main/java/io/seats/seatingChart/TicketTypeWithQuantity.java
@@ -1,0 +1,17 @@
+package io.seats.seatingChart;
+
+import com.google.gson.annotations.Expose;
+
+public class TicketTypeWithQuantity {
+
+    @Expose
+    public String ticketType;
+
+    @Expose
+    public int quantity;
+
+    public TicketTypeWithQuantity(String ticketType, int quantity) {
+        this.ticketType = ticketType;
+        this.quantity = quantity;
+    }
+}

--- a/seatsio-android-component/src/main/java/io/seats/utils/Function3.java
+++ b/seatsio-android-component/src/main/java/io/seats/utils/Function3.java
@@ -1,0 +1,6 @@
+package io.seats.utils;
+
+public interface Function3<T1, T2, T3, R> {
+
+    R apply(T1 t1, T2 t2, T3 t3);
+}

--- a/seatsio-android-sample/src/main/java/test/ShowEventManagerActivity.java
+++ b/seatsio-android-sample/src/main/java/test/ShowEventManagerActivity.java
@@ -2,6 +2,7 @@ package test;
 
 import static io.seats.Region.EU;
 import static io.seats.eventManager.EventManagerMode.MANAGE_OBJECT_STATUSES;
+import static io.seats.eventManager.EventManagerMode.SELECT;
 import static io.seats.seatingChart.ColorScheme.DARK;
 
 import android.graphics.Color;
@@ -12,16 +13,19 @@ import androidx.appcompat.app.AppCompatActivity;
 
 import io.seats.eventManager.EventManagerConfig;
 import io.seats.eventManager.EventManagerView;
+import io.seats.eventManager.ManageObjectStatusesModeConfig;
+import io.seats.eventManager.SelectModeConfig;
 
 public class ShowEventManagerActivity extends AppCompatActivity {
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        EventManagerConfig config = new EventManagerConfig()
+        EventManagerConfig config = new SelectModeConfig()
+                .setMaxSelectedObjects(4)
                 .setSecretKey("...")
-                .setEvent("smallTheatreWithGAEvent")
-                .setMode(MANAGE_OBJECT_STATUSES)
+                .setEvent("fa78299a-6b61-4bf3-99c8-8434a79be17e")
+                .setMode(SELECT)
                 .setLanguage("nl")
                 .setObjectColor("(object, dflt, extraConfig) => object.channel ? 'blue': 'red'")
                 .setTooltipInfo(object -> object.channel != null ? "in channel" : "not in channel")


### PR DESCRIPTION
Not all config options were represented in the Android client. This PR adds them, along with sub-classes of `EventManagerConfig` to allow those modes have the necessary config.

Further work is still required on exposing EM mode callsbacks and functions, these will be in a separate PR.

This PR allows the Prompts API to be used, with support for JS callbacks within Java callbacks.