### PR TITLE
Add new options to Colors

### DIFF
--- a/seatsio-android-component/src/main/java/io/seats/seatingChart/Colors.java
+++ b/seatsio-android-component/src/main/java/io/seats/seatingChart/Colors.java
@@ -13,6 +13,15 @@ public class Colors {
     @Expose
     public String colorTitle;
 
+    @Expose
+    public String availableObjectColor;
+
+    @Expose
+    public String selectedObjectColor;
+
+    @Expose
+    public String errorColor;
+
     public Colors setColorSelected(String colorSelected) {
         this.colorSelected = colorSelected;
         return this;
@@ -25,6 +34,21 @@ public class Colors {
 
     public Colors setColorTitle(String colorTitle) {
         this.colorTitle = colorTitle;
+        return this;
+    }
+
+    public Colors setAvailableObjectColor(String availableObjectColor) {
+        this.availableObjectColor = availableObjectColor;
+        return this;
+    }
+
+    public Colors setSelectedObjectColor(String selectedObjectColor) {
+        this.selectedObjectColor = selectedObjectColor;
+        return this;
+    }
+
+    public Colors setErrorColor(String errorColor) {
+        this.errorColor = errorColor;
         return this;
     }
 }


### PR DESCRIPTION
The `Colors` class was behind the times with regards to what can be possibly defined for those options. This PR updates `Colors` to match what's in the UI.