### PR TITLE
unifiedObjectPropertiesInCallbacks should always be true

### DIFF
--- a/seatsio-android-component/src/main/java/io/seats/seatingChart/SeatingChartConfig.java
+++ b/seatsio-android-component/src/main/java/io/seats/seatingChart/SeatingChartConfig.java
@@ -144,7 +144,7 @@ public class SeatingChartConfig extends CommonConfig<SeatingChartConfig, Seating
     public CategoryFilter categoryFilter;
 
     @Expose
-    public Boolean unifiedObjectPropertiesInCallbacks;
+    public final Boolean unifiedObjectPropertiesInCallbacks = true;
 
     @Expose
     public Boolean hideSectionsNotForSale;
@@ -505,11 +505,6 @@ public class SeatingChartConfig extends CommonConfig<SeatingChartConfig, Seating
 
     public SeatingChartConfig setCategoryFilter(CategoryFilter categoryFilter) {
         this.categoryFilter = categoryFilter;
-        return this;
-    }
-
-    public SeatingChartConfig setUnifiedObjectPropertiesInCallbacks(Boolean unifiedObjectPropertiesInCallbacks) {
-        this.unifiedObjectPropertiesInCallbacks = unifiedObjectPropertiesInCallbacks;
         return this;
     }
 


### PR DESCRIPTION
unifiedObjectPropertiesInCallbacks is a legacy setting that has been fixed to `true` for all user accounts created after May 15th 2019.  As a result, allowing mutation of this value is no longer supported.